### PR TITLE
Although it's claimed that fluentd_output_status_num_errors's metrics…

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -52,7 +52,7 @@
           {
             alert: 'FluentdErrorsHigh',
             expr: |||
-              fluentd_output_status_num_errors > %(fluentdNumErrors)s
+              sum by(instance, job) (rate(fluentd_output_status_num_errors[1m])) > 10
             ||| % $._config,
             'for': '1m',
             labels: {


### PR DESCRIPTION
… type

is "gauge" in the scraped result [1], the value is incremental and behaves
like a "counter" type.  Thus, to get the current value, use the "rate"
function.

[1] - TYPE fluentd_output_status_num_errors gauge

Submitted an issue: https://github.com/fluent/fluent-plugin-prometheus/issues/88